### PR TITLE
lazy load apps with suspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,27 @@
 # Change history for platform-complete
 
-## 1.0.0 (IN PROGRESS)
-* Add oai-pmh module. Refs MODOAIPMH-94.
-* Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.
-* Update `react-intl` to `^5.7.0`, STRIPES-694
-* Update `moment` to `~2.29.0`. STRIPES-702
+## 2022r1 what's the story morning glory?
+
+* lazy loading 
+
+## 2021r3 lotus
+
+* Update `react` to `v17`. Refs STRIPES-722.
+* Provide `rxjs` `v6`. Refs STRIPES-723.
+* Lock to `react-intl` `v5.21.1`. Refs FOLIO-3342.
+* Lock to `colors` `1.4.0`. Refs FOLIO-3383.
+
+## 2021r2 kiwi
+
 * Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 * Provide `react-titled`. Refs STCOR-503.
 * Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
 * Provide `react-query` and `swr`. Refs STRIPES-735.
-* Update `react` to `v171. Refs STRIPES-722.
-* Provide `rxjs` `v6`. Refs STRIPES-723.
-* Lock to `react-intl` `v5.21.1`. Refs FOLIO-3342.
-* Lock to `colors` `1.4.0`. Refs FOLIO-3383.
+
+## ancient history
+
+* Add oai-pmh module. Refs MODOAIPMH-94.
+* Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.
+* Update `react-intl` to `^5.7.0`, STRIPES-694
+* Update `moment` to `~2.29.0`. STRIPES-702
+

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
   },
   "resolutions": {
     "@folio/stripes-cli": "^2.4.0",
+    "@folio/stripes-core": "folio-org/stripes-core#lazy-loading-modules",
+    "@folio/stripes-webpack": "folio-org/stripes-webpack#lazy-loading-ui-modules",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
     "final-form": "^4.20.4",


### PR DESCRIPTION
Wrap UI modules in `<Suspense>` to support lazy loading. This has the
potential to greatly reduce the initial bundle size, speeding up the
load-time for the initial login page.